### PR TITLE
feat: cleanse topics prior to each test run

### DIFF
--- a/examples/test_pubsub_marker.py
+++ b/examples/test_pubsub_marker.py
@@ -24,7 +24,6 @@ class TestPubsubMarker:
         path_1 = publisher.topic_path(project_id, topics[0])
         path_2 = publisher.topic_path(project_id, topics[1])
 
-        assert len(topics) == 2 == len(found_topics)
         assert path_1 in found_topics
         assert path_2 in found_topics
         assert project_id == Defaults.PROJECT_ID

--- a/pytest_streaming/pubsub/publisher.py
+++ b/pytest_streaming/pubsub/publisher.py
@@ -25,9 +25,14 @@ class GCPPublisher(pubsub_v1.PublisherClient):  # type: ignore[misc]
         if safety and not self.emulator_enabled:
             raise EnvironmentError("Pubsub required to have the emulator enabled")
 
+        project_path = f"projects/{project_id}"
+
         self.delete_testing_topics(project_id, topics)
         for topic in topics:
             topic_path = self.topic_path(project_id, topic)
+
+            if topic_path in [t.name for t in self.list_topics(request={"project": project_path})]:  # pragma: no cover
+                raise ValueError("Topic still exists and was not properly cleaned up prior to test run")
             self.create_topic(name=topic_path)
 
     def delete_testing_topics(self, project_id: str, topics: list[str], safety: bool = True) -> None:

--- a/pytest_streaming/pulsar/markers.py
+++ b/pytest_streaming/pulsar/markers.py
@@ -112,8 +112,8 @@ class PulsarMarker(BaseMarker):
             yield
             return
 
+        client = PulsarClientWrapper(service_url=self.service_url, admin_url=self.admin_url)
         try:
-            client = PulsarClientWrapper(service_url=self.service_url, admin_url=self.admin_url)
             client.setup_testing_topics(
                 tenant=self._tenant,
                 namespace=self._namespace,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from google.api_core.exceptions import NotFound
 from pytest import Config
 
 from pytest_streaming.pubsub.publisher import GCPPublisher
@@ -36,34 +35,3 @@ def publisher() -> GCPPublisher:
 @pytest.fixture(scope="session")
 def pulsar_client(pulsar_settings: PulsarTestSettings) -> PulsarClientWrapper:
     return PulsarClientWrapper(service_url=pulsar_settings.service_url, admin_url=pulsar_settings.admin_url)
-
-
-@pytest.fixture(scope="session", autouse=True)
-def destroy_pubsub_topics(pubsub_project_ids: list[str], publisher: GCPPublisher) -> None:
-    """Ensures the pubsub topics are cleansed prior to each test.
-
-    Args:
-        pubsub_project_ids (fixture: list[str]): List of project IDs to clean up.
-        publisher (fixture: GCPPublisher): The GCPPublisher instance to use for cleanup.
-    """
-    for project_id in pubsub_project_ids:
-        project_path = f"projects/{project_id}"
-        found_topics = publisher.list_topics(request={"project": project_path})
-        found_topics = [topic.name for topic in found_topics]
-
-        for topic in found_topics:
-            try:
-                publisher.delete_topic(topic=topic)
-            except NotFound:
-                ...
-
-
-@pytest.fixture(scope="session", autouse=True)
-def destroy_pulsar_topics(pulsar_client: PulsarClientWrapper) -> None:
-    """Ensures the pulsar topics are cleaned up prior to the test suite running.
-
-    Args:
-        pulsar_client (fixture: PulsarClientWrapper): The Pulsar client instance to use for cleanup.
-    """
-    # TODO: add support for custom namespace and tenants
-    pulsar_client._delete_tenant(tenant="public")

--- a/tests/pubsub/enums.py
+++ b/tests/pubsub/enums.py
@@ -10,6 +10,7 @@ class PubsubProjectId(StrEnum):
     FIXTURE = "pytest-streaming-fixture-pubsub"
     FIXTURE_DELETE = "pytest-streaming-fixture-pubsub-delete"
     PUBLISHER_CREATE = "pytest-streaming-publisher-pubsub-create"
+    PUBLISHER_CREATE_CLEAN = "pytest-streaming-publisher-pubsub-create-clean"
     PUBLISHER_DELETE = "pytest-streaming-publisher-pubsub-delete"
 
 

--- a/tests/pubsub/test_pubsub_publisher.py
+++ b/tests/pubsub/test_pubsub_publisher.py
@@ -16,6 +16,19 @@ class TestPubsubPublisher:
             topic_path = publisher.topic_path(project_id, topic)
             assert topic_path in [t.name for t in publisher.list_topics(request={"project": project_path})]
 
+    def test_pubsub_topics_create_clean(self, publisher: GCPPublisher) -> None:
+        project_id = PubsubProjectId.PUBLISHER_CREATE_CLEAN
+        topic = "topic1"
+        project_path = f"projects/{project_id}"
+
+        topic_path = publisher.topic_path(project=project_id, topic=topic)
+        publisher.delete_testing_topics(project_id, [topic])
+
+        publisher.create_topic(name=topic_path)
+
+        publisher.setup_testing_topics(project_id, [topic])
+        assert topic_path in [t.name for t in publisher.list_topics(request={"project": project_path})]
+
     def test_pubsub_topics_delete(self, publisher: GCPPublisher) -> None:
         project_id = PubsubProjectId.PUBLISHER_DELETE
         topics = ["topic1", "topic2"]


### PR DESCRIPTION
# Description

By default, each test should run in isolation. Thus the topics being used for each test should be net-new and cleansed of any prior data.

# Changes Made

1. Delete pulsar topics prior to each run
2. Extra validations and tests for each streaming provider

# Issue Link

#44 